### PR TITLE
feat(auth): support single-tenant app registrations via TENANT_ID env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # Copy this file to .env and fill in your Azure AD application's client ID.
 # See AZURE_SETUP.md for instructions on creating an app registration.
 CLIENT_ID=
+
+# Tenant ID — required for single-tenant app registrations ("common" if unset).
+TENANT_ID=

--- a/AZURE_SETUP.md
+++ b/AZURE_SETUP.md
@@ -217,6 +217,9 @@ The new device code login will request all permissions for your currently enable
 **"AADSTS50020: User account from identity provider does not exist in tenant"**
 → Make sure you selected **"Multitenant and personal Microsoft accounts"** in step 2, not "Single tenant".
 
+**"AADSTS50059: No tenant-identifying information found"**
+→ Your app registration is **single tenant**, which the default `/common` endpoint rejects. Either switch the registration to multitenant, or set `TENANT_ID=<your-tenant-id>` in `.env` (or the environment) to authenticate against your tenant directly.
+
 **"AADSTS7000218: The request body must contain the following parameter: 'client_assertion' or 'client_secret'"**
 → Make sure **"Allow public client flows"** is set to **Yes** in the Authentication settings (step 3).
 

--- a/auth.go
+++ b/auth.go
@@ -10,16 +10,29 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/joho/godotenv"
 )
 
-const (
-	tenant = "common"
-)
+// resolveTenant returns the Entra tenant for the auth endpoints:
+// TENANT_ID from the environment/.env if set, otherwise "common".
+// Single-tenant app registrations must set TENANT_ID — the /common
+// endpoint rejects them with AADSTS50059.
+func resolveTenant() string {
+	_ = godotenv.Load()
+	if t := os.Getenv("TENANT_ID"); t != "" {
+		return t
+	}
+	return "common"
+}
 
-var (
-	deviceCodeURL = fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/devicecode", tenant)
-	tokenURL      = fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenant)
-)
+func deviceCodeURL() string {
+	return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/devicecode", resolveTenant())
+}
+
+func tokenURL() string {
+	return fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", resolveTenant())
+}
 
 // DeviceCodeResponse is the response from the device code endpoint.
 type DeviceCodeResponse struct {
@@ -98,7 +111,7 @@ func StartDeviceFlow(clientID, scopes string) (*DeviceCodeResponse, error) {
 		"client_id": {clientID},
 		"scope":     {scopes},
 	}
-	resp, err := http.PostForm(deviceCodeURL, form)
+	resp, err := http.PostForm(deviceCodeURL(), form)
 	if err != nil {
 		return nil, fmt.Errorf("device code request failed: %w", err)
 	}
@@ -129,7 +142,7 @@ func PollForToken(clientID, deviceCode string, interval int) (*TokenResponse, er
 			"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
 			"device_code": {deviceCode},
 		}
-		resp, err := http.PostForm(tokenURL, form)
+		resp, err := http.PostForm(tokenURL(), form)
 		if err != nil {
 			return nil, fmt.Errorf("token poll request failed: %w", err)
 		}
@@ -174,7 +187,7 @@ func RefreshAccessToken(clientID, refreshToken, scopes string) (*TokenResponse, 
 		"refresh_token": {refreshToken},
 		"scope":         {scopes},
 	}
-	resp, err := http.PostForm(tokenURL, form)
+	resp, err := http.PostForm(tokenURL(), form)
 	if err != nil {
 		return nil, fmt.Errorf("refresh request failed: %w", err)
 	}


### PR DESCRIPTION
## Problem

The auth endpoints are hardcoded to the `/common` tenant. Microsoft Entra rejects device code requests through `/common` for app registrations that are set to "Accounts in this organizational directory only":

```
AADSTS50059: No tenant-identifying information found in either the request
or implied by any provided credentials.
```

AZURE_SETUP.md asks for a multitenant registration, but some org policies do not allow multitenant apps, so those users cannot authenticate at all.

## Change

- Add an optional `TENANT_ID` variable, read from the environment or `.env`. When set, the device code, token poll, and refresh endpoints all use that tenant. When unset, behavior is unchanged (`/common`).
- Resolve the tenant at request time instead of package init, so the value from `.env` is picked up regardless of load order.
- Document the variable in `.env.example` and add an AADSTS50059 entry to the AZURE_SETUP.md troubleshooting section.

## Testing

- `go build`, `go vet`, and `go test ./...` pass.
- Verified against a real single-tenant registration: `/common` fails with AADSTS50059, and with `TENANT_ID` set the device code flow completes and the app signs in.